### PR TITLE
handle explicit errors better

### DIFF
--- a/src/erllambda.erl
+++ b/src/erllambda.erl
@@ -322,8 +322,10 @@ format_reqid( ReqId, Format, Values ) ->
 format( Format, Values ) ->
     iolist_to_binary( io_lib:format( Format, Values ) ).
 
-complete( #{success := _} = Response) ->
+% in success case we care only about the body
+complete( #{success := Response}) ->
     complete( result, Response );
+% in error we care about the entire error object
 complete( #{errorType := _} = Response) ->
     complete( failure, Response).
 


### PR DESCRIPTION
```
** Generic server erllambda_poller terminating ** Last message in was poll ** When Server state == {state,<<"127.0.0.1:9001">>,search_filter,#Ref<0.3851618716.2192048130.9713>,undefined} ** Reason for termination == ** {function_clause,[{erllambda_poller,encode_body,['HandlerFailure'],[{file,"/home/jenkins/workspace/search-filter/_build/default/lib/erllambda/src/erllambda_poller.erl"},{line,211}]},{erllambda_poller,invoke_error,3,[{file,"/home/jenkins/workspace/search-filter/_build/default/lib/erllambda/src/erllambda_poller.erl"},{line,190}]},{erllambda_poller,handle_info,2,[{file,"/home/jenkins/workspace/search-filter/_build/default/lib/erllambda/src/erllambda_poller.erl"},{line,128}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,616}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,686}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
```

@velimir0xff 
double checking that in my private stack atm