### PR TITLE
do not detect region based on IWS_BASESTACKNAME env variable

### DIFF
--- a/src/erllambda_util.erl
+++ b/src/erllambda_util.erl
@@ -198,8 +198,7 @@ environ_() ->
     Environ.
 
 environ_env() ->
-    %% makeincl sets ENVIRON and IWS containers set IWS_BASESTACKNAME
-    case os:getenv( "ENVIRON", os:getenv( "IWS_BASESTACKNAME" ) ) of
+    case os:getenv( "ENVIRON" ) of
         false -> undefined;
         Environ -> list_to_binary(Environ)
     end.

--- a/test/erllambda_util_SUITE.erl
+++ b/test/erllambda_util_SUITE.erl
@@ -44,7 +44,7 @@ groups() ->
                test_region_instancedoc]},
      {accountid, [test_accountid_config, test_accountid_instancedoc,
                   test_accountid_sts]},
-     {environ, [test_environ_devenv, test_environ_env, test_environ_config,
+     {environ, [test_environ_devenv, test_environ_config,
                 test_environ_file]}
     ].
 
@@ -129,13 +129,6 @@ test_environ_devenv( _Config ) ->
     %% reset env to verify original value cached
     os:putenv( "ENVIRON", "budder" ),
     ?assertEqual( <<"fudder">>, erllambda:environ() ).
-
-test_environ_env( _Config ) ->
-    os:putenv( "IWS_BASESTACKNAME", "blabla" ),
-    ?assertEqual( <<"blabla">>, erllambda:environ() ),
-    %% reset env to verify original value cached
-    os:putenv( "IWS_BASESTACKNAME", "flafla" ),
-    ?assertEqual( <<"blabla">>, erllambda:environ() ).
 
 test_environ_config( _Config ) ->
     Environ = <<"jaba-wat">>,
@@ -235,5 +228,4 @@ clear( accountid ) ->
 clear( environ ) ->
     true = os:unsetenv( "ENVIRON" ),
     ok = application:unset_env( erllambda, environ ),
-    true = os:unsetenv( "IWS_BASESTACKNAME" ),
     ok.


### PR DESCRIPTION
this was used by internal tooling

related to #29