### PR TITLE
allow specify code loading mode through CODE_LOADING_MODE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ Current testing has shown that it does not make sense to run Erlang
 on AWS Lambda functions with less then 256MB RAM.
 Having 512-1024MB is optimal for most of the use cases.
 
+### Configuration
+
+#### Code loading mode
+
+Depending on a use case, erlang [code loading mode](http://erlang.org/doc/man/code.html)
+[can](https://github.com/alertlogic/erllambda/issues/46) significantly affect execution performance.
+
+To switch between `interactive` or `embedded` modes set `CODE_LOADING_MODE` environment variable on
+AWS Lambda function creation step with a desired value:
+
+<pre>
+aws --profile default --region &lt;region&gt; \
+ lambda create-function \
+ --function-name &lt;your_function&gt; \
+ --memory-size 1024 \
+ --handler &lt;your_function_module_name&gt; \
+ --zip-file fileb://_build/prod/&lt;your_function&gt;-0.0.0.zip \
+ <b>--environment "Variables={CODE_LOADING_MODE=interactive}"</b>
+ --runtime provided \
+ --role &lt;role-arn&gt;
+</pre>
+
 ### Basic Deployment
 
 See [Erllambda Example](https://github.com/alertlogic/erllambda_example) for the step-by-step procedure to deploy your Lambda.

--- a/priv/erlang-start
+++ b/priv/erlang-start
@@ -32,6 +32,7 @@ export NATIVELIB_DIR=${ERTS_LIB_DIR}
 export REL_NAME="$(basename $SCRIPT)"
 PROGNAME=appmod;
 export ERL_CRASH_DUMP="/dev/null"
+CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
 
 replace_os_vars() {
     awk '{
@@ -61,7 +62,7 @@ ARGS="$@"
 
 set -- "$ERTS_DIR/bin/erlexec" -noshell -noinput -Bd \
      -boot "$REL_DIR/$REL_NAME" \
-     -mode embedded \
+     -mode "$CODE_LOADING_MODE" \
      -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
      -config "$CONFIG_PATH" \
      -args_file "$VMARGS_PATH"


### PR DESCRIPTION
[Seems like](https://github.com/alertlogic/erllambda/issues/46#issuecomment-449844680) code loading mode can have significant performance effect.
This PR allows to choose between 2 modes.

Can be specified on a creation step in CFN template:
``` yaml
  BootTestFunction:
    Type: 'AWS::Serverless::Function'
    Properties:
      Handler: erllambda_sam_boot_test
      CodeUri: ../_build/prod/rel/erllambda_sam_boot_test-1.0.0.zip
      Description: >-
        Function to test boot time
      Runtime: provided
      MemorySize: 256
      Timeout: 10
      Environment:
        Variables:
          CODE_LOADING_MODE: !Ref CodeLoadingMode
```

For complete example see: https://github.com/velimir/erllambda_sam_boot_test/blob/b7f4e3980354876394e31f3e17f27789f6a4d9ef/etc/template.yaml#L21-L33