### PR TITLE
fix wrong argument for  `erllambda_config_srv:serialize/2`

### DIFF
--- a/src/erllambda_util.erl
+++ b/src/erllambda_util.erl
@@ -306,7 +306,7 @@ config( Region, Options ) ->
         {ok, Result} -> Result;
         {error, not_found} ->
             Generate = config_generate( Key, Region, Options ),
-            erllambda_config_srv:serialize( Region, Generate )
+            erllambda_config_srv:serialize( Key, Generate )
     end.
 
 config_generate( Key, Region, Options ) ->


### PR DESCRIPTION
` erllambda_config_srv:serialize/2` should accept `Key` as first argument and not `Region`.