### PR TITLE
Add LOG macro for module and line number in logs

### DIFF
--- a/include/erllambda.hrl
+++ b/include/erllambda.hrl
@@ -5,6 +5,9 @@
 %% @copyright 2018 Alert Logic, Inc.
 %%%---------------------------------------------------------------------------
 
+-ifndef(__ERLLAMBDA_HRL__).
+-define(__ERLLAMBDA_HRL__, 1).
+
 %%******************************************************************************
 %% Type Definitions
 %%******************************************************************************
@@ -27,3 +30,9 @@
 -define(DAY_MSECS, 86400000).
 -define(AWSEVICT_SECS, (application:get_env(erllambda, default_role_evict_sec, 60))).
 -define(AWSEVICT_MSECS, (?AWSEVICT_SECS * 1000)).
+
+-define(LOG(Msg), erllambda:message("~p:~p ~s", [?MODULE, ?LINE, Msg])).
+-define(LOG(Fmt, Args), erllambda:message("~p:~p " ++ Fmt, [?MODULE, ?LINE | Args])).
+
+
+-endif.

--- a/test/erllambda_logging_handler.erl
+++ b/test/erllambda_logging_handler.erl
@@ -1,5 +1,7 @@
 -module(erllambda_logging_handler).
 
+-include("erllambda.hrl").
+
 %% API
 -export([handle/2]).
 
@@ -11,4 +13,6 @@ handle(_Event, _Context) ->
     erllambda:message("Starting logs test"),
     erllambda:message("This line should not break logging", []),
     erllambda:message("This and any further logs should be printed"),
+    ?LOG("Using LOG macro should give module and line numbers in the logs"),
+    ?LOG("~s ~p", ["LOG macro using format", 42]),
     {ok, "done"}.


### PR DESCRIPTION
* ?LOG(Msg) and ?LOG(Fmt, Args) added.
* Extended logging test to exercise the ?LOG macros.
* Protect erlambda.hrl against double include.