### PR TITLE
Fix config functions spec

### DIFF
--- a/src/erllambda_util.erl
+++ b/src/erllambda_util.erl
@@ -208,7 +208,7 @@ environ_config() ->
 
 
 %%------------------------------------------------------------------------------
--spec config() -> #aws_config{}.
+-spec config() -> #aws_config{} | {error, term()}.
 %%------------------------------------------------------------------------------
 %% @doc Generate and cache an erlcloud configuration
 %%
@@ -222,7 +222,7 @@ config() -> config( region(), [] ).
 
     
 %%------------------------------------------------------------------------------
--spec config( Services :: [service()] ) -> #aws_config{}.
+-spec config( Services :: [service()] ) -> #aws_config{} | {error, term()}.
 %%------------------------------------------------------------------------------
 %% @doc Generate and cache an erlcloud configuration
 %%
@@ -238,7 +238,7 @@ config( Services ) -> config( region(), [{services, Services}] ).
 
     
 %%------------------------------------------------------------------------------
--spec config( Region :: region(), Options :: [option()] ) -> #aws_config{} | undefined.
+-spec config( Region :: region(), Options :: [option()] ) -> #aws_config{} | undefined | {error, term()}.
 %%------------------------------------------------------------------------------
 %% @doc Generate and cache an erlcloud configuration
 %%


### PR DESCRIPTION
Config functions may return `{error, SomeHttpError}` in case of AWS STS errors during assume role step.
This PR not about fixing this behaviour, and no a breaking change. 
It's only about fixing spec.