### PR TITLE
Add flag for erllambda_error_handler

### DIFF
--- a/src/erllambda.app.src
+++ b/src/erllambda.app.src
@@ -38,7 +38,10 @@
     {handler_spawn_opts, [
      {min_bin_vheap_size, 2487399},
      {min_heap_size, 2487399}
-    ]}
+    ]},
+    %% defines whether or not "erllambda_error_handler"
+    %% should be added on startup to error_logger
+    {enable_error_handler, true}
    ]},
   {modules, []},
   {licenses, ["MIT"]},

--- a/src/erllambda_app.erl
+++ b/src/erllambda_app.erl
@@ -20,11 +20,21 @@
 
 start(_StartType, _StartArgs) ->
     Sup = erllambda_sup:start_link(),
-    error_logger:tty(false),
-    error_logger:add_report_handler(erllambda_error_handler),
+    case application:get_env(erllambda, enable_error_handler) of
+        {ok, true} ->
+            error_logger:tty(false),
+            error_logger:add_report_handler(erllambda_error_handler);
+        _ ->
+            ok
+    end,
     Sup.
 
 %%--------------------------------------------------------------------
 stop(_State) ->
-    error_logger:delete_report_handler(erllambda_error_handler),
+    case application:get_env(erllambda, enable_error_handler) of
+        {ok, true} ->
+            error_logger:delete_report_handler(erllambda_error_handler);
+        _ ->
+            ok
+    end,
     ok.


### PR DESCRIPTION
**Problem:** `erllambda_error_handler` is not always needed (e.g. in cases when `erllambda` is used outside of Lambda environment (e.g. local dev) and for configuration purposes only, etc) and may add unwanted log lines duplication.
**Solution:** make if configurable.