### PR TITLE
Update priv/erlang-start for newer relx

### DIFF
--- a/priv/erlang-start
+++ b/priv/erlang-start
@@ -49,6 +49,13 @@ export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
 export LD_LIBRARY_PATH="${ERTS_DIR}/lib:${LD_LIBRARY_PATH}"
 
+# Newer versions of relx/rebar3 generate a start.boot file instead of a $REL_NAME.boot file
+# Note that the .boot suffix is not specified, so default to "start" if it exists, otherwise fall back to "$REL_NAME"
+BOOTFILE="start"
+if [ ! -f "$REL_DIR/start.boot" ]; then
+    BOOTFILE="$REL_NAME"
+fi
+
 # disable Erlang crash dumps and Linux core dumps
 export ERL_CRASH_DUMP="/dev/null"
 ulimit -c 0
@@ -57,7 +64,7 @@ ulimit -c 0
 ARGS="$@"
 
 set -- "$ERTS_DIR/bin/erlexec" -noshell -noinput -Bd \
-     -boot "$REL_DIR/$REL_NAME" \
+     -boot "$REL_DIR/$BOOTFILE" \
      -mode "$CODE_LOADING_MODE" \
      -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
      -config "$CONFIG_PATH" \


### PR DESCRIPTION
* Update priv/erlang-start for newer relx, either using start.boot or REL_NAME.boot as boot file

This applies a fix to priv/erlang-start that is similar to the one done for basic start scripts in relx itself: https://github.com/erlware/relx/commit/98053bd3904bce681c36715ae271bb7d56a88764#diff-805ba880d71fd6e26d3b46ba46652f49b97464a20909343e9acd532fdee1ad06R50

Fixes https://github.com/alertlogic/rebar3_erllambda/issues/27.